### PR TITLE
Added canonical data models

### DIFF
--- a/src/CanonicalTypes.elm
+++ b/src/CanonicalTypes.elm
@@ -1,0 +1,30 @@
+module CanonicalTypes exposing (..)
+
+
+-- Map will change with the development of this library
+type alias Map = MultiPolygon
+
+
+-- (longitude, latitude)
+type alias Position = (Float, Float)
+
+-- Point consists of a single position
+type alias Point = Position
+
+-- MultiPoint consists of multiple positions
+type alias MultiPoint = List Position
+
+-- LineString consists of two or more positions
+-- A LinearRing is closed LineString with 4 or more positions.
+type alias LineString = List Position
+
+-- MultiLineString consists of two or more positions
+type alias MultiLineString = List (List Position)
+
+-- Polygon consists of LinearRing coordinate arrays.
+-- For Polygons with multiple rings, the first must be the exterior ring
+-- and any others must be interior rings or holes.
+type alias Polygon = List Position
+
+-- MultiPolygon consists of an array of Polygon coordinate arrays
+type alias MultiPolygon = List (List Position)

--- a/src/GeoJsonParsers.elm
+++ b/src/GeoJsonParsers.elm
@@ -1,10 +1,10 @@
-module GeoJsonHelpers exposing (..)
+module GeoJsonParsers exposing (..)
 
 import Tuple exposing (first, second)
 import String exposing (concat)
 import Json.Encode
 import GeoJson exposing
-  (GeoJson, GeoJsonObject(..), Geometry(..), FeatureObject)
+  (GeoJson, GeoJsonObject(..), Geometry(..), FeatureObject, decoder)
 
 
 parseFeatureObject : GeoJson -> Maybe FeatureObject
@@ -101,3 +101,19 @@ generatePolygonStrings geojson =
       |> List.map (\polygon -> (String.concat (List.intersperse " " polygon)))
   in
     polygonStrings
+
+parseToCanonicalModel : GeoJson -> List (List (Float, Float))
+parseToCanonicalModel geojson =
+  geojson
+      |> parseFeatureCollection
+      |> Maybe.withDefault []
+      |> List.head
+      |> Maybe.withDefault
+        { geometry = Nothing
+        , properties = Json.Encode.string ""
+        , id = Nothing
+        }
+      |> .geometry
+      |> Maybe.withDefault (Point (0, 0, []))
+      |> parsePolygonCoordinates
+

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -3,7 +3,7 @@ module Tests exposing (..)
 
 import Tuple exposing (first, second)
 import GeoJson exposing (..)
-import GeoJsonHelpers exposing (..)
+import GeoJsonParsers exposing (..)
 import Test exposing (..)
 import Json.Encode
 import Expect


### PR DESCRIPTION
These unified models represent GeoJson in many ways. As GeoJson is the first data format to be supported, this is expected. Ideally, these models will more or less stay the same even as other data formats are supported in the future (pbf). 

With these models, a map consists of a list of polygons. I anticipate that as additional layers are added to the map, further differentiation will be needed. At that point, I think that the map model will be a list of Layer objects, where a layer consists of a list of polygons (objects) and perhaps some metadata (layer name, layer position). To prevent over-complication at this time, I'm assuming 1 layer (base-layer). 

@wittjosiah Thoughts/concerns? 